### PR TITLE
use Fastly-Key instead of X-Fastly-Key

### DIFF
--- a/lib/capistrano/fastly.rb
+++ b/lib/capistrano/fastly.rb
@@ -18,7 +18,7 @@ module Capistrano
             http.verify_mode = OpenSSL::SSL::VERIFY_NONE
             request = Net::HTTP::Post.new("/service/#{fastly_config[:service_id]}/purge_all")
             request.add_field('Content-Type', 'application/json')
-            request.add_field('X-Fastly-Key', fastly_config[:api_key])
+            request.add_field('Fastly-Key', fastly_config[:api_key])
             request.body = ""
             response = http.request(request)
 

--- a/spec/fixtures/vcr_cassettes/fastly_purge_all.yml
+++ b/spec/fixtures/vcr_cassettes/fastly_purge_all.yml
@@ -13,7 +13,7 @@ http_interactions:
       - Ruby
       Content-Type:
       - application/json
-      X-Fastly-Key:
+      Fastly-Key:
       - YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
   response:
     status:


### PR DESCRIPTION
The use of `X-Fastly-Key` is deprecated and will not be supported long term. This branch replaces any occurrences of `X-Fastly-Key` with `Fastly-Key`.
